### PR TITLE
chore: simplify CI workflow and update GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,9 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
         java: [17, 21]
     
     steps:
@@ -24,10 +23,9 @@ jobs:
         distribution: 'temurin'
     
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@v3
     
     - name: Grant execute permission for gradlew
-      if: runner.os != 'Windows'
       run: chmod +x gradlew
     
     - name: Run tests
@@ -41,12 +39,12 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: test-results-${{ matrix.os }}-java${{ matrix.java }}
+        name: test-results-java${{ matrix.java }}
         path: build/test-results/
     
     - name: Upload coverage reports
-      if: matrix.os == 'ubuntu-latest' && matrix.java == '17'
-      uses: codecov/codecov-action@v3
+      if: matrix.java == '17'
+      uses: codecov/codecov-action@v4
       with:
         file: build/reports/jacoco/test/jacocoTestReport.xml
         flags: unittests
@@ -66,7 +64,7 @@ jobs:
         distribution: 'temurin'
     
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@v3
     
     - name: Build with Gradle
       run: ./gradlew build
@@ -92,6 +90,6 @@ jobs:
         output: 'trivy-results.sarif'
     
     - name: Upload Trivy results to GitHub Security
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Description

Simplify CI workflow and update GitHub Actions versions.

## Changes Made
- Simplify test matrix to use only ubuntu-latest (remove Windows and macOS)
- Update gradle/gradle-build-action from v2 to v3
- Update codecov/codecov-action from v3 to v4
- Update github/codeql-action/upload-sarif from v2 to v3
- Remove conditional for gradlew permission (no longer needed with ubuntu-only)
- Simplify test artifact naming without OS matrix
