### PR TITLE
feat: add SPDX license headers to all source files

### DIFF
--- a/LICENSE.header
+++ b/LICENSE.header
@@ -1,0 +1,4 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,9 @@ spotless {
         // Target all Java source files
         target("src/**/*.java")
 
+        // License header
+        licenseHeaderFile(rootProject.file("LICENSE.header"))
+
         // Remove unused imports
         removeUnusedImports()
 

--- a/src/main/java/com/lucimber/crypto/bcrypt/BCryptBase64.java
+++ b/src/main/java/com/lucimber/crypto/bcrypt/BCryptBase64.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 /**

--- a/src/main/java/com/lucimber/crypto/bcrypt/BCryptEngine.java
+++ b/src/main/java/com/lucimber/crypto/bcrypt/BCryptEngine.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 import java.security.SecureRandom;

--- a/src/main/java/com/lucimber/crypto/bcrypt/BCryptService.java
+++ b/src/main/java/com/lucimber/crypto/bcrypt/BCryptService.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 /**

--- a/src/main/java/com/lucimber/crypto/bcrypt/BCryptVersion.java
+++ b/src/main/java/com/lucimber/crypto/bcrypt/BCryptVersion.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 /**

--- a/src/main/java/com/lucimber/crypto/bcrypt/CostFactor.java
+++ b/src/main/java/com/lucimber/crypto/bcrypt/CostFactor.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 /**

--- a/src/main/java/com/lucimber/crypto/bcrypt/Hash.java
+++ b/src/main/java/com/lucimber/crypto/bcrypt/Hash.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 import java.util.Objects;

--- a/src/main/java/com/lucimber/crypto/bcrypt/Password.java
+++ b/src/main/java/com/lucimber/crypto/bcrypt/Password.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/com/lucimber/crypto/bcrypt/Salt.java
+++ b/src/main/java/com/lucimber/crypto/bcrypt/Salt.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 import java.security.SecureRandom;

--- a/src/main/java/com/lucimber/crypto/bcrypt/Usage.java
+++ b/src/main/java/com/lucimber/crypto/bcrypt/Usage.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 /**

--- a/src/test/java/com/lucimber/crypto/bcrypt/BCryptServiceTest.java
+++ b/src/test/java/com/lucimber/crypto/bcrypt/BCryptServiceTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/lucimber/crypto/bcrypt/BouncyCastleHelper.java
+++ b/src/test/java/com/lucimber/crypto/bcrypt/BouncyCastleHelper.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 import org.bouncycastle.crypto.generators.OpenBSDBCrypt;

--- a/src/test/java/com/lucimber/crypto/bcrypt/EdgeCaseEncodingTest.java
+++ b/src/test/java/com/lucimber/crypto/bcrypt/EdgeCaseEncodingTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/lucimber/crypto/bcrypt/EdgeCaseHashTest.java
+++ b/src/test/java/com/lucimber/crypto/bcrypt/EdgeCaseHashTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/lucimber/crypto/bcrypt/EdgeCasePasswordTest.java
+++ b/src/test/java/com/lucimber/crypto/bcrypt/EdgeCasePasswordTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/lucimber/crypto/bcrypt/EdgeCaseSaltTest.java
+++ b/src/test/java/com/lucimber/crypto/bcrypt/EdgeCaseSaltTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/lucimber/crypto/bcrypt/HashTest.java
+++ b/src/test/java/com/lucimber/crypto/bcrypt/HashTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/lucimber/crypto/bcrypt/PasswordTest.java
+++ b/src/test/java/com/lucimber/crypto/bcrypt/PasswordTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/lucimber/crypto/bcrypt/SaltTest.java
+++ b/src/test/java/com/lucimber/crypto/bcrypt/SaltTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/lucimber/crypto/bcrypt/integration/BouncyCastleIntegrationTest.java
+++ b/src/test/java/com/lucimber/crypto/bcrypt/integration/BouncyCastleIntegrationTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt.integration;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/lucimber/crypto/bcrypt/integration/CrossCompatibilityTest.java
+++ b/src/test/java/com/lucimber/crypto/bcrypt/integration/CrossCompatibilityTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt.integration;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/lucimber/crypto/bcrypt/integration/SpringSecurityIntegrationTest.java
+++ b/src/test/java/com/lucimber/crypto/bcrypt/integration/SpringSecurityIntegrationTest.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.lucimber.crypto.bcrypt.integration;
 
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
## Description
Adds SPDX license headers to all source files.
- Added LICENSE.header file with SPDX format
- Configured Spotless to apply license headers
- Applied headers to all 21 Java source files
- Using SPDX-FileCopyrightText: 2025 Lucimber UG
- Using SPDX-License-Identifier: Apache-2.0

Verified with spotlessCheck - all formatting correct.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Testing
- [x] Unit tests pass locally (`./gradlew test`)
- [x] Integration tests pass (`./gradlew test --tests "*IntegrationTest"`)
- [ ] New tests added for new functionality
- [x] All tests achieve 100% pass rate

## Test Coverage
- [ ] New code is covered by tests
- [ ] Edge cases are tested
- [ ] Error conditions are tested

## Compatibility
- [ ] Verified compatibility with Spring Security
- [ ] Verified compatibility with Bouncy Castle
- [x] No breaking changes to public API

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added Javadoc for all public methods
- [ ] I have updated the CHANGELOG.md if needed
