### PR TITLE
feat: add Maven Central publishing configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Lucimber UG
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 plugins {
     id("java-library")
-    id("maven-publish")
+    // Style and formatting
     id("com.diffplug.spotless") version "7.2.1"
+    // Publishing
+    id("com.vanniktech.maven.publish") version "0.34.0"
+    id("signing")
 }
 
 group = "com.lucimber"
@@ -10,8 +18,7 @@ version = "1.0.0"
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
-    withJavadocJar()
-    withSourcesJar()
+    // Javadoc and sources JARs are handled by the Vanniktech Maven Publish plugin
 }
 
 repositories {
@@ -19,6 +26,7 @@ repositories {
 }
 
 dependencies {
+    // Testing
     testImplementation("org.junit.jupiter:junit-jupiter:5.13.4")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
@@ -54,15 +62,6 @@ tasks.jar {
                 "Built-JDK" to System.getProperty("java.version"),
             ),
         )
-    }
-}
-
-publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            from(components["java"])
-            artifactId = "lucimber-bcrypt"
-        }
     }
 }
 
@@ -108,4 +107,48 @@ spotless {
         target("*.gradle.kts")
         ktlint()
     }
+}
+
+// Publishing configuration
+mavenPublishing {
+    publishToMavenCentral()
+
+    signAllPublications()
+
+    coordinates("com.lucimber", "lucimber-bcrypt", "1.0.0")
+
+    pom {
+        name.set("Bcrypt")
+        description.set("A zero-dependency, implementation of the BCrypt password hashing algorithm.")
+        inceptionYear.set("2025")
+        url.set("https://github.com/lucimber/bcrypt-java")
+
+        licenses {
+            license {
+                name.set("Apache License, Version 2.0")
+                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+        }
+
+        developers {
+            developer {
+                id.set("lucimber")
+                name.set("Lucimber UG")
+                url.set("https://github.com/lucimber/")
+                email.set("devdev@lucimber.com")
+            }
+        }
+
+        scm {
+            connection.set("scm:git:git://github.com/lucimber/bcrypt-java.git")
+            developerConnection.set("scm:git:ssh://github.com:lucimber/bcrypt-java.git")
+            url.set("https://github.com/lucimber/bcrypt-java")
+        }
+    }
+}
+
+// Configure signing to use GPG
+signing {
+    useGpgCmd()
 }


### PR DESCRIPTION
## Description
Adds Maven Central publishing configuration via Vanniktech Maven Publish plugin.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Changes Made
- Added Vanniktech Maven Publish plugin for streamlined publishing
- Added signing plugin with GPG configuration
- Configured complete POM metadata for Maven Central requirements
- Added SPDX license header to build.gradle.kts
- Removed manual publishing configuration in favor of plugin
- Set up coordinates as com.lucimber:lucimber-bcrypt:1.0.0

Publishing features:
- publishToMavenLocal - for local testing
- publishToMavenCentral - for staging to Sonatype
- publishAndReleaseToMavenCentral - for automatic release
- Automatic signing of all artifacts with GPG

## Testing
- [x] Unit tests pass locally (`./gradlew test`)
- [x] Integration tests pass (`./gradlew test --tests "*IntegrationTest"`)
- [ ] New tests added for new functionality
- [x] All tests achieve 100% pass rate

## Test Coverage
- [ ] New code is covered by tests
- [ ] Edge cases are tested
- [ ] Error conditions are tested

## Compatibility
- [ ] Verified compatibility with Spring Security
- [ ] Verified compatibility with Bouncy Castle
- [x] No breaking changes to public API

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added Javadoc for all public methods
- [ ] I have updated the CHANGELOG.md if needed