### PR TITLE
docs: reset CHANGELOG.md for initial v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0] - 2025-01-11
 
-### Changed
-- bump actions/stale from 9 to 10 (#1) @dependabot[bot]
-- deps(deps): bump org.springframework.security:spring-security-crypto from 6.2.1 to 6.5.3 (#6) @dependabot[bot]
-- bump actions/checkout from 4 to 5 (#3) @dependabot[bot]
-- deps(deps): bump org.junit.jupiter:junit-jupiter from 5.10.1 to 5.13.4 (#9) @dependabot[bot]
-- bump actions/github-script from 7 to 8 (#4) @dependabot[bot]
-- bump gradle/gradle-build-action from 2 to 3 (#5) @dependabot[bot]
-- deps(deps): bump commons-logging:commons-logging from 1.3.0 to 1.3.5 (#7) @dependabot[bot]
-- deps(deps): bump org.bouncycastle:bcprov-jdk18on from 1.77 to 1.81 (#8) @dependabot[bot]
+### Added
+- Initial release of lucimber-bcrypt library
+- Pure Java implementation of BCrypt password hashing algorithm
+- Zero runtime dependencies
+- Support for BCrypt 2a and 2b variants
+- Full compatibility with Spring Security BCrypt
+- Full compatibility with Bouncy Castle BCrypt
+- Domain-driven design with immutable value objects
+- Comprehensive test suite (110 tests)
+- Java 9+ module support (JPMS)
+- Self-documenting JAR with usage help
+- Maven Central publishing configuration
+- SPDX license headers
+
+### Features
+- `BCryptService` - Main service interface (singleton pattern)
+- `Password` - Secure password value object with memory clearing
+- `Hash` - BCrypt hash representation with parsing and validation
+- `Salt` - 16-byte salt with BCrypt Base64 encoding
+- `CostFactor` - Work factor configuration (4-31)
+- `BCryptVersion` - Algorithm version enum (2a/2b)
+- Constant-time password comparison for security
+- Automatic password truncation at 72 bytes (BCrypt specification)
+- SecureRandom for salt generation
+
+### Security
+- Constant-time comparison to prevent timing attacks
+- Secure memory handling with Password.clear() method
+- Rejection of empty passwords
+- Default cost factor of 10 for balanced security/performance
+
+[1.0.0]: https://github.com/lucimber/bcrypt-java/releases/tag/v1.0.0


### PR DESCRIPTION


## Description
Resets CHANGELOG.md since this is the first public release of the lucimber-bcrypt library.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Changes Made
- Removed old unreleased dependency update entries
- Added comprehensive changelog for v1.0.0 initial release
- Documented all major features and capabilities
- Added security features section
- Set release date to 2025-01-11