### PR TITLE
fix: correct GitHub release workflow issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,23 +21,14 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v3
     
-    - name: Build release
+    - name: Build and Test
       run: ./gradlew build
-    
-    - name: Run tests
-      run: ./gradlew test
     
     - name: Generate Javadoc
       run: ./gradlew javadoc
     
-    - name: Create Release JAR
-      run: ./gradlew jar
-    
-    - name: Create Source JAR
-      run: ./gradlew sourcesJar
-    
-    - name: Create Javadoc JAR  
-      run: ./gradlew javadocJar
+    - name: Generate Javadoc JAR
+      run: ./gradlew plainJavadocJar
     
     - name: Get version
       id: get_version
@@ -62,8 +53,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: build/libs/bcrypt-${{ steps.get_version.outputs.VERSION }}.jar
-        asset_name: bcrypt-${{ steps.get_version.outputs.VERSION }}.jar
+        asset_path: build/libs/lucimber-bcrypt-${{ steps.get_version.outputs.VERSION }}.jar
+        asset_name: lucimber-bcrypt-${{ steps.get_version.outputs.VERSION }}.jar
         asset_content_type: application/java-archive
     
     - name: Upload Sources JAR
@@ -72,8 +63,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: build/libs/bcrypt-${{ steps.get_version.outputs.VERSION }}-sources.jar
-        asset_name: bcrypt-${{ steps.get_version.outputs.VERSION }}-sources.jar
+        asset_path: build/libs/lucimber-bcrypt-${{ steps.get_version.outputs.VERSION }}-sources.jar
+        asset_name: lucimber-bcrypt-${{ steps.get_version.outputs.VERSION }}-sources.jar
         asset_content_type: application/java-archive
     
     - name: Upload Javadoc JAR
@@ -82,6 +73,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: build/libs/bcrypt-${{ steps.get_version.outputs.VERSION }}-javadoc.jar
-        asset_name: bcrypt-${{ steps.get_version.outputs.VERSION }}-javadoc.jar
+        asset_path: build/libs/lucimber-bcrypt-${{ steps.get_version.outputs.VERSION }}-javadoc.jar
+        asset_name: lucimber-bcrypt-${{ steps.get_version.outputs.VERSION }}-javadoc.jar
         asset_content_type: application/java-archive


### PR DESCRIPTION
## Description
Corrects GitHub release workflow issues

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Changes Made
- Removed duplicate test execution (build already includes tests)
- Fixed javadocJar task name to plainJavadocJar (Vanniktech plugin)
- Updated artifact names from 'bcrypt' to 'lucimber-bcrypt'
- Simplified workflow by combining build and test step

The workflow now correctly:
1. Runs build once (which includes tests)
2. Generates proper Javadoc JAR using plainJavadocJar task
3. Uploads artifacts with correct naming convention

## Testing
- [ ] Unit tests pass locally (`./gradlew test`)
- [ ] Integration tests pass (`./gradlew test --tests "*IntegrationTest"`)
- [ ] New tests added for new functionality
- [x] All tests achieve 100% pass rate

## Test Coverage
- [ ] New code is covered by tests
- [ ] Edge cases are tested
- [ ] Error conditions are tested

## Compatibility
- [ ] Verified compatibility with Spring Security
- [ ] Verified compatibility with Bouncy Castle
- [x] No breaking changes to public API

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added Javadoc for all public methods
- [ ] I have updated the CHANGELOG.md if needed